### PR TITLE
Fix typo in withTridentFont parameter

### DIFF
--- a/src/main/kotlin/cc/pe3epwithyou/trident/utils/extensions/ComponentExtensions.kt
+++ b/src/main/kotlin/cc/pe3epwithyou/trident/utils/extensions/ComponentExtensions.kt
@@ -16,6 +16,6 @@ object ComponentExtensions {
 
     fun MutableComponent.defaultFont(): MutableComponent = this.withFont(Style.DEFAULT_FONT)
 
-    fun MutableComponent.withTridentFont(font: String = "icon", offest: Int = 0): MutableComponent =
-        this.withFont(TridentFont.getTridentFont(font, offest))
+    fun MutableComponent.withTridentFont(font: String = "icon", offset: Int = 0): MutableComponent =
+        this.withFont(TridentFont.getTridentFont(font, offset))
 }


### PR DESCRIPTION
## Summary
- fix typo in `withTridentFont` extension so callers can use `offset` named parameter

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68c7d8ca77f48329a25788d8b33a22ee