### PR TITLE
Add CI workflow and 1.21.4 build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - mc: "1.21.8"
+            fabric: "0.131.0+1.21.8"
+            yacl: "3.7.1+1.21.6-fabric"
+            sheeplib: "1.4.2+1.21.8"
+          - mc: "1.21.4"
+            fabric: "0.127.0+1.21.4"
+            yacl: "3.7.1+1.21.4-fabric"
+            sheeplib: "1.4.2+1.21.4"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: gradle
+      - name: Build
+        run: ./gradlew build -Pminecraft_version=${{ matrix.mc }} -Pfabric_version=${{ matrix.fabric }} -Pyacl_version=${{ matrix.yacl }} -Psheeplib_version=${{ matrix.sheeplib }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Trident
 Client-side utility mod for [MCC Island](https://mcchampionship.com/island/), providing a huge range of utility and quality of life features.
 
 ## Requirements
-- Minecraft 1.21.8
+- Minecraft 1.21.8 (1.21.4 port available)
 - [Yet Another Config Lib](https://modrinth.com/mod/yacl)
 - [Fabric Language Kotlin](https://modrinth.com/mod/fabric-language-kotlin)
 - [Noxesium](https://modrinth.com/mod/noxesium)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
     modImplementation("net.fabricmc:fabric-language-kotlin:${project.property("kotlin_loader_version")}")
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:${project.property("fabric_version")}")
-    include(modImplementation("com.noxcrew.sheeplib:api:1.4.2+1.21.8")!!)
+    include(modImplementation("com.noxcrew.sheeplib:api:${project.property("sheeplib_version")}")!!)
     modImplementation("dev.isxander:yet-another-config-lib:${project.property("yacl_version")}")
     modImplementation("com.terraformersmc:modmenu:${project.property("modmenu_version")}")
     modImplementation("com.noxcrew.noxesium:fabric:2.7.7")

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,4 @@ archives_base_name=Trident
 fabric_version=0.131.0+1.21.8
 yacl_version=3.7.1+1.21.6-fabric
 modmenu_version=14.0.0-rc.2
+sheeplib_version=1.4.2+1.21.8


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds for Minecraft 1.21.8 and 1.21.4
- make sheeplib dependency version configurable for multi-version builds
- document availability of 1.21.4 port

## Testing
- `gradle build`
- `gradle build -Pminecraft_version=1.21.4 -Pfabric_version=0.127.0+1.21.4 -Pyacl_version=3.7.1+1.21.4-fabric -Psheeplib_version=1.4.2+1.21.4` *(failed: Failed download after 3 attempts)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d8658e3083299f467f4976edad29